### PR TITLE
Enable upload form example and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Webflow GCS Uploader
+
+This Vercel project exposes serverless endpoints for uploading and downloading files to Google Cloud Storage. It can be used to implement a simple "WeTransfer" style workflow.
+
+## Endpoints
+
+- `POST /api/upload` – Generates a signed URL for uploading a file directly to GCS. Accepts `filename`, `contentType` and optional `message` in the request body. Returns the signed `uploadUrl`, the `publicId` of the file and a `shareUrl` which can be sent to clients.
+- `GET /api/download?publicId=...` – Streams the file back to the requester and forces a download.
+- `GET /api/share?publicId=...` – Serves a small HTML page showing the file name and message with a link to download.
+
+Set the service account JSON in `GCS_KEY` and optionally configure `BASE_URL` if your deployment domain differs from the request origin.
+
+An example upload form using these endpoints is provided in [`example.html`](example.html).

--- a/api/share.mjs
+++ b/api/share.mjs
@@ -1,0 +1,81 @@
+import { Storage } from "@google-cloud/storage";
+
+export default async (req, res) => {
+  const allowedOrigins = [
+    "https://www.wikingmedia.com",
+    "https://wiking-media.webflow.io",
+    "https://webflow-gcs-uploader.vercel.app"
+  ];
+  const origin = req.headers.origin;
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
+  res.setHeader("Vary", "Origin");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Max-Age", "86400");
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).send("Method Not Allowed. Only GET allowed.");
+  }
+
+  try {
+    if (!process.env.GCS_KEY) {
+      console.error("Environment variable GCS_KEY is not set.");
+      return res.status(500).json({ error: "Server configuration error: GCS_KEY missing." });
+    }
+    const { publicId } = req.query;
+    if (!publicId) {
+      return res.status(400).json({ error: "Missing publicId" });
+    }
+    const serviceAccount = JSON.parse(process.env.GCS_KEY);
+    const storage = new Storage({
+      projectId: serviceAccount.project_id,
+      credentials: {
+        client_email: serviceAccount.client_email,
+        private_key: serviceAccount.private_key.replace(/\\n/g, "\n"),
+      },
+    });
+    const BUCKET_NAME = "wiking-portal";
+    const file = storage.bucket(BUCKET_NAME).file(publicId);
+    let metadata;
+    try {
+      [metadata] = await file.getMetadata();
+    } catch (err) {
+      if (err.code === 404) {
+        return res.status(404).send("File not found");
+      }
+      throw err;
+    }
+    const message = metadata.metadata ? metadata.metadata.message : "";
+    const originalFileName = publicId.includes("-") ? publicId.substring(publicId.indexOf("-") + 1) : publicId;
+    const baseUrl = process.env.BASE_URL || req.headers.origin || "";
+    const sanitizedBase = baseUrl.replace(/\/$/, "");
+    const downloadLink = `${sanitizedBase}/api/download?publicId=${encodeURIComponent(publicId)}`;
+
+    const escapeHtml = (str) => str.replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+
+    const safeName = escapeHtml(originalFileName);
+    const safeMessage = message ? escapeHtml(message) : "";
+
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.end(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${safeName}</title></head><body>
+<h1>${safeName}</h1>
+${safeMessage ? `<p>${safeMessage}</p>` : ''}
+<p><a href="${downloadLink}">Download file</a></p>
+</body></html>`);
+  } catch (error) {
+    console.error("Error in share endpoint", error);
+    if (error instanceof SyntaxError && error.message.includes('JSON')) {
+      return res.status(500).json({ error: 'Server configuration error: GCS_KEY is not valid JSON. Check format.' });
+    }
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
+};
+

--- a/example.html
+++ b/example.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+<meta charset="UTF-8">
+<title>Filuppladdning</title>
+<style>
+  .upload-container {
+    font-family: 'Arial', sans-serif;
+    max-width: 500px;
+    margin: 40px auto;
+    padding: 30px;
+    border-radius: 10px;
+    background-color: #f9f9f9;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+    text-align: center;
+  }
+  .upload-container h2 {
+    color: #2c3e50;
+    margin-bottom: 25px;
+    font-size: 1.8em;
+  }
+  .upload-container p {
+    color: #7f8c8d;
+    font-size: 0.95em;
+    margin-bottom: 30px;
+    line-height: 1.5;
+  }
+  .upload-container input[type="file"],
+  .upload-container input[type="text"] {
+    display: block;
+    width: calc(100% - 20px);
+    padding: 12px 10px;
+    margin-bottom: 20px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-sizing: border-box;
+    font-size: 1em;
+  }
+  .upload-container input[type="file"] {
+    display: none;
+  }
+  .upload-container .custom-file-upload {
+    border: 2px dashed #3498db;
+    background-color: #ecf0f1;
+    color: #3498db;
+    padding: 15px 20px;
+    cursor: pointer;
+    border-radius: 5px;
+    margin-bottom: 20px;
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+    font-weight: bold;
+    font-size: 1em;
+    display: block;
+  }
+  .upload-container .custom-file-upload:hover {
+    background-color: #e0e6e7;
+    border-color: #2980b9;
+  }
+  .upload-container button {
+    background-color: #2ecc71;
+    color: white;
+    padding: 12px 25px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1.1em;
+    font-weight: bold;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    width: 100%;
+  }
+  .upload-container button:hover {
+    background-color: #27ae60;
+    transform: translateY(-2px);
+  }
+  #result {
+    margin-top: 30px;
+    padding: 15px;
+    border-radius: 5px;
+    background-color: #e7f3e7;
+    color: #27ae60;
+    font-weight: bold;
+    border: 1px solid #27ae60;
+    display: none;
+  }
+  #result.error {
+    background-color: #fde0e0;
+    color: #c0392b;
+    border-color: #c0392b;
+  }
+  @media (max-width: 600px) {
+    .upload-container {
+      margin: 20px;
+      padding: 20px;
+    }
+  }
+</style>
+</head>
+<body>
+<div class="upload-container">
+  <h2>Ladda upp fil</h2>
+  <p>Välj din fil och lägg till ett meddelande som beskriver filen för mottagaren.</p>
+
+  <label for="fileInput" class="custom-file-upload">Välj fil</label>
+  <input type="file" id="fileInput" accept="*/*">
+  <input type="text" id="messageInput" placeholder="Skriv ett meddelande här..." maxlength="200">
+
+  <button id="uploadBtn">Ladda upp</button>
+  <div id="result"></div>
+</div>
+
+<script>
+const fileInput = document.getElementById('fileInput');
+const messageInput = document.getElementById('messageInput');
+const uploadBtn = document.getElementById('uploadBtn');
+const resultDiv = document.getElementById('result');
+const customFileUploadLabel = document.querySelector('.custom-file-upload');
+
+const API_BASE = 'https://webflow-gcs-uploader.vercel.app'; // ändra till din domän
+
+fileInput.addEventListener('change', () => {
+  if (fileInput.files.length > 0) {
+    customFileUploadLabel.textContent = `Vald fil: ${fileInput.files[0].name}`;
+  } else {
+    customFileUploadLabel.textContent = 'Välj fil';
+  }
+});
+
+uploadBtn.addEventListener('click', async () => {
+  const file = fileInput.files[0];
+  const message = messageInput.value.trim();
+
+  resultDiv.style.display = 'none';
+  resultDiv.classList.remove('error');
+  resultDiv.textContent = '';
+
+  if (!file) {
+    displayResult('Vänligen välj en fil först.', true);
+    return;
+  }
+  if (!message) {
+    displayResult('Vänligen skriv ett meddelande till filen.', true);
+    return;
+  }
+
+  uploadBtn.textContent = 'Laddar upp...';
+  uploadBtn.disabled = true;
+
+  const filename = file.name;
+  const contentType = file.type || 'application/octet-stream';
+
+  try {
+    const response = await fetch(`${API_BASE}/api/upload`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename, contentType, message })
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || 'Något gick fel vid förberedelse av uppladdning.');
+    }
+
+    const { uploadUrl, shareUrl } = data;
+
+    const uploadResponse = await fetch(uploadUrl, {
+      method: 'PUT',
+      body: file,
+    });
+    if (!uploadResponse.ok) {
+      throw new Error('Filen kunde inte laddas upp till molnlagringen.');
+    }
+
+    displayResult(`Filen \"${filename}\" har laddats upp! <a href="${shareUrl}" target="_blank">Dela länk</a>`);
+
+    fileInput.value = '';
+    messageInput.value = '';
+    customFileUploadLabel.textContent = 'Välj fil';
+  } catch (error) {
+    console.error('Uppladdningsfel:', error);
+    displayResult(`Fel vid uppladdning: ${error.message}`, true);
+  } finally {
+    uploadBtn.textContent = 'Ladda upp';
+    uploadBtn.disabled = false;
+  }
+});
+
+function displayResult(message, isError = false) {
+  resultDiv.innerHTML = message;
+  resultDiv.style.display = 'block';
+  if (isError) {
+    resultDiv.classList.add('error');
+  } else {
+    resultDiv.classList.remove('error');
+  }
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- clean up Swedish comments and unused variables
- return direct links in share endpoint using BASE_URL
- document new environment variable and example form
- add example HTML form demonstrating upload flow

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684a611e6c308331b9e9281faf3359a2